### PR TITLE
update selections endpoint description

### DIFF
--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -5,8 +5,9 @@ post:
     This endpoint should be used by a validator client running as part of a distributed validator cluster, and is 
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
-    to correctly determine if one of its validators has been selected to perform an aggregation duty in this slot. 
-    Consensus clients need not support this endpoint and may return a 501.
+    to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
+    Validator clients must query this endpoint at the start of an epoch for all validators. Consensus clients need
+    not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -6,8 +6,8 @@ post:
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
     to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
-    Validator clients must query this endpoint at the start of an epoch for all validators. Consensus clients need
-    not support this endpoint and may return a 501.
+    Validator clients must query this endpoint at the start of an epoch for all validators that have attester duties 
+    in that epoch. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -6,9 +6,9 @@ post:
     committee selection. This endpoint should be used by a validator client running as part of a distributed 
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
-    allow a validator client to correctly determine if one of its validators has been selected to perform an 
-    aggregation duty in a slot. Validator clients must query this endpoint at the start of an epoch for all 
-    validators. Consensus clients need not support this endpoint and may return a 501.
+    allow a validator client to correctly determine if one of its validators has been selected to perform a 
+    sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
+    at the start of an epoch for all validators. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -8,7 +8,8 @@ post:
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
     allow a validator client to correctly determine if one of its validators has been selected to perform a 
     sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
-    at the start of an epoch for all validators. Consensus clients need not support this endpoint and may return a 501.
+    at the start of an epoch for all validators that have sync committee contribution duties in that epoch. 
+    Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -6,9 +6,9 @@ post:
     committee selection. This endpoint should be used by a validator client running as part of a distributed 
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
-    allow a validator client to correctly determine if one of its validators has been selected to perform 
-    a sync committee contribution (sync aggregation) duty in this slot. Consensus clients need not support 
-    this endpoint and may return a 501.
+    allow a validator client to correctly determine if one of its validators has been selected to perform an 
+    aggregation duty in a slot. Validator clients must query this endpoint at the start of an epoch for all 
+    validators. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:


### PR DESCRIPTION
Update endpoint descriptions for selections endpoints:
* `/eth/v1/validator/beacon_committee_selections`
* `/eth/v1/validator/sync_committee_selections`

This PR updates endpoint description to explicitly state that "validator clients must query selections endpoints at the start of an epoch".