### PR TITLE
add lookahead epochs

### DIFF
--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -6,8 +6,8 @@ post:
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
     to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
-    Validator clients must query this endpoint at the start of an epoch for all validators that have attester duties 
-    in that epoch. Consensus clients need not support this endpoint and may return a 501.
+    Validator clients must query this endpoint at the start of an epoch for the lookahead epochs (current and next epochs) for
+    all validators that have attester duties in the lookahead epochs. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -5,7 +5,7 @@ post:
     This endpoint should be used by a validator client running as part of a distributed validator cluster, and is 
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
-    to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
+    to correctly determine if any of its validators has been selected to perform an attestation aggregation duty in a slot. 
     Validator clients must query this endpoint at the start of an epoch for the current and lookahead (next) epochs for
     all validators that have attester duties in the current and lookahead epochs. Consensus clients need not support this
     endpoint and may return a 501.

--- a/apis/validator/beacon_committee_selections.yaml
+++ b/apis/validator/beacon_committee_selections.yaml
@@ -6,8 +6,9 @@ post:
     implemented by a distributed validator middleware client. This endpoint is used to exchange partial 
     selection proofs for combined/aggregated selection proofs to allow a validator client 
     to correctly determine if one of its validators has been selected to perform an aggregation duty in a slot. 
-    Validator clients must query this endpoint at the start of an epoch for the lookahead epochs (current and next epochs) for
-    all validators that have attester duties in the lookahead epochs. Consensus clients need not support this endpoint and may return a 501.
+    Validator clients must query this endpoint at the start of an epoch for the current and lookahead (next) epochs for
+    all validators that have attester duties in the current and lookahead epochs. Consensus clients need not support this
+    endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -8,8 +8,9 @@ post:
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
     allow a validator client to correctly determine if one of its validators has been selected to perform a 
     sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
-    at the start of an epoch for the lookahead epochs (current and next epochs) for for all validators that have
-    sync committee contribution duties in the lookahead epochs. Consensus clients need not support this endpoint and may return a 501.
+    at the start of an epoch for the current and lookahead (next) epochs for all validators that have
+    sync committee contribution duties in the current and lookahead epochs. Consensus clients need not support this 
+    endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -5,12 +5,11 @@ post:
     Submit sync committee selections to a DVT middleware client. It returns the threshold aggregated sync 
     committee selection. This endpoint should be used by a validator client running as part of a distributed 
     validator cluster, and is implemented by a distributed validator middleware client. This endpoint is 
-    used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
-    allow a validator client to correctly determine if one of its validators has been selected to perform a 
+    used to exchange partial selection proofs (slot signatures) for combined/aggregated selection proofs to 
+    allow a validator client to correctly determine if any of its validators has been selected to perform a 
     sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
-    at the start of an epoch for the current and lookahead (next) epochs for all validators that have
-    sync committee contribution duties in the current and lookahead epochs. Consensus clients need not support this 
-    endpoint and may return a 501.
+    at the start of each slot for all validators that are included in the current sync committee. Consensus
+    clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:

--- a/apis/validator/sync_committee_selections.yaml
+++ b/apis/validator/sync_committee_selections.yaml
@@ -8,8 +8,8 @@ post:
     used to exchange partial selection proof slot signatures for combined/aggregated selection proofs to 
     allow a validator client to correctly determine if one of its validators has been selected to perform a 
     sync committee contribution (sync aggregation) duty in a slot. Validator clients must query this endpoint
-    at the start of an epoch for all validators that have sync committee contribution duties in that epoch. 
-    Consensus clients need not support this endpoint and may return a 501.
+    at the start of an epoch for the lookahead epochs (current and next epochs) for for all validators that have
+    sync committee contribution duties in the lookahead epochs. Consensus clients need not support this endpoint and may return a 501.
   tags:
     - Validator
   requestBody:


### PR DESCRIPTION
Update selections endpoints description to add explicitly state that "validator clients must query at the start of an epoch for the current and [lookahead](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#lookahead) epochs (current and next epochs)".